### PR TITLE
Update grottserver.py to be able use registers up to 4096

### DIFF
--- a/grottserver.py
+++ b/grottserver.py
@@ -313,7 +313,7 @@ class GrottHttpRequestHandler(http.server.BaseHTTPRequestHandler):
                     # test if register is specified and set reg value. 
                     if command == "register":
                         #test if valid reg is applied
-                        if int(urlquery["register"][0]) >= 0 and int(urlquery["register"][0]) < 1125 : 
+                        if int(urlquery["register"][0]) >= 0 and int(urlquery["register"][0]) < 4096 : 
                             register = urlquery["register"][0]
                         else: 
                             responsetxt = b'invalid reg value specified'
@@ -549,7 +549,7 @@ class GrottHttpRequestHandler(http.server.BaseHTTPRequestHandler):
 
                     if command == "register":
                         #test if valid reg is applied
-                        if int(urlquery["register"][0]) >= 0 and int(urlquery["register"][0]) < 1024 : 
+                        if int(urlquery["register"][0]) >= 0 and int(urlquery["register"][0]) < 4096 : 
                             register = urlquery["register"][0]
                         else: 
                             responsetxt = b'invalid reg value specified'


### PR DESCRIPTION
Updated grottserver.py to be able to read registers above 1125 and to write registers above 1024. Allow both read and write to the registers up to 4096 as Growatt currently use up to register 3374 and will likely go higher in the future.