### PR TITLE
Update grottserver.py to be able use multiple registers up to 4096

### DIFF
--- a/grottserver.py
+++ b/grottserver.py
@@ -581,7 +581,7 @@ class GrottHttpRequestHandler(http.server.BaseHTTPRequestHandler):
                         # TODO: Too much copy/paste here. Refactor into methods.
 
                         # Check for valid start register
-                        if int(urlquery["startregister"][0]) >= 0 and int(urlquery["startregister"][0]) < 1125 :
+                        if int(urlquery["startregister"][0]) >= 0 and int(urlquery["startregister"][0]) < 4096 :
                             startregister = urlquery["startregister"][0]
                         else:
                             responsetxt = b'invalid start register value specified'
@@ -591,7 +591,7 @@ class GrottHttpRequestHandler(http.server.BaseHTTPRequestHandler):
                             return
 
                         # Check for valid end register
-                        if int(urlquery["endregister"][0]) >= 0 and int(urlquery["endregister"][0]) < 1125 :
+                        if int(urlquery["endregister"][0]) >= 0 and int(urlquery["endregister"][0]) < 4096 :
                             endregister = urlquery["endregister"][0]
                         else:
                             responsetxt = b'invalid end register value specified'


### PR DESCRIPTION
Updated grottserver.py to be able to use the multiple registers above 1125 Allow both read and write to the registers up to 4096 as Growatt currently use up to register 3374 and will likely go higher in the future.